### PR TITLE
Adding support to download the complete datasets as fragments

### DIFF
--- a/README
+++ b/README
@@ -86,8 +86,11 @@ file rdf_linkeddata.json that looks something like:
         "void": {
                   "pagetitle": "VoID Description for my dataset"
                 },
-	"expires" : "A86400" ,
-        "fragments" : { "fragments_path" : "/fragments" }	
+	      "expires" : "A86400" ,
+        "fragments" : { 
+                "fragments_path" : "/fragments" ,
+                "allow_dump_dataset" : 0
+        }	
   }
  
 In your shell set

--- a/lib/RDF/LinkedData.pm
+++ b/lib/RDF/LinkedData.pm
@@ -350,7 +350,8 @@ sub response {
 		}
 
 		log_debug {'Getting fragment with this selector ' . Dumper(\%statement) };
-		return _client_error($response, 'Returning the whole database not allowed') unless any { defined } values(%statement);
+		return _client_error($response, 'Returning the whole database not allowed') 
+				unless $self->fragments_config->{allow_dump_dataset} || any { defined } values(%statement);
 		my $output_model = $self->_common_fragments_control;
 
 		my $iterator = $self->model->get_statements($statement{subject}, $statement{predicate}, $statement{object});

--- a/rdf_linkeddata_void.json
+++ b/rdf_linkeddata_void.json
@@ -14,7 +14,10 @@
 	}
     },
 
-    "fragments" : { "fragments_path" : "/fragments" },
+    "fragments" : { 
+    	"fragments_path" : "/fragments" , 
+    	"allow_dump_dataset" : 0
+    },
 
     "namespaces" : { "rdfs" : "http://www.w3.org/2000/01/rdf-schema#", 
 	             "dct" : "http://purl.org/dc/terms/" },

--- a/t/18-fragments.t
+++ b/t/18-fragments.t
@@ -229,6 +229,29 @@ my $void_subject = iri($base_uri . '/#dataset-0');
 				  "Control statements OK");
 }
 
+{
+	note 'Testing the allow_dump_dataset feature';
+
+	my $ld = RDF::LinkedData->new(model => $model,
+											base_uri => $base_uri, 
+											namespaces_as_vocabularies => 1, 
+											void_config => { urispace => 'http://localhost' }, 
+											fragments_config => { %$ec , allow_dump_dataset => 1 }
+										  );
+
+	isa_ok($ld, 'RDF::LinkedData');
+
+	$ld->request(Plack::Request->new({}));
+
+	{
+		my $response = $ld->response($base_uri . '/fragments?subject=&predicate=&object=');	
+		isa_ok($response, 'Plack::Response');
+		is($response->status, 200, "Returns 200 with all parameters empty");
+		my $retmodel = return_model($response->content, $parser);
+		has_literal("4", undef, $xsd->integer, $retmodel, 'Triple count is correct got all 4 triples');
+	}
+}
+
 sub return_model {
 	my ($content, $parser) = @_;
 	my $retmodel = RDF::Trine::Model->temporary_model;


### PR DESCRIPTION
Suggested edit to allow for a complete dump of the dataset in the fragments interface when no filter statements are provided